### PR TITLE
Debug should be in dependencies because dev dependencies of dependencies...

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "main": "lib/index.js",
   "license": "MIT",
   "dependencies": {
+    "debug": "^1.0.2",
     "minimatch": "^1.0.0"
   },
   "devDependencies": {
-    "metalsmith": "0.x",
-    "debug": "^1.0.2"
+    "metalsmith": "0.x"
   }
 }


### PR DESCRIPTION
... (transative dev deps) aren't installed when running npm install.
